### PR TITLE
Update to 3.0.2, add GPhoto support, Fixes #27 and #4

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,8 +26,8 @@ apps:
 parts:
   darktable:
     plugin: cmake
-    source: https://github.com/darktable-org/darktable/releases/download/release-3.0.1/darktable-3.0.1.tar.xz
-    source-checksum: sha256/c54b3921da14a97c99ab2f79feca468cf2abca65adf907dba6216e47edab7cb7
+    source: https://github.com/darktable-org/darktable/releases/download/release-3.0.2/darktable-3.0.2.tar.xz
+    source-checksum: sha256/6abaf661fe9414e92bdb33b58b98ef024ccf6132b7876abaf0751ec2109f36fb
     configflags:
       - -DCMAKE_BUILD_TYPE=Release
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,14 @@ grade: stable
 confinement: strict
 base: core18
 
+layout:
+  /usr/lib/x86_64-linux-gnu/libgpm.so.2:
+    bind-file: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgpm.so
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgphoto2:
+    bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgphoto2
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgphoto2_port:
+    bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgphoto2_port
+
 apps:
   darktable:
     command: usr/bin/darktable --datadir $SNAP/usr/share/darktable --moduledir $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/darktable --configdir $SNAP_USER_DATA --localedir $SNAP/usr/share/locale
@@ -22,6 +30,10 @@ apps:
       - password-manager-service
       - network
       - network-bind
+      - raw-usb
+      - camera
+      - hardware-observe
+      - mount-observe
 
 parts:
   darktable:
@@ -74,7 +86,7 @@ parts:
       #
       # Camera detection/tethering/importing doesn't work, with no denials.
       # Need to investigate further before enabling this.
-      # - libgphoto2-dev
+      - libgphoto2-dev
       #
       # Need to test with cups-control interface
       # - libcups2-dev
@@ -98,3 +110,6 @@ parts:
       - libwebpmux3
       - libwmf0.2-7
       - libsecret-1-0
+      - libexif12
+      - libgphoto2-6
+      - libgphoto2-port12


### PR DESCRIPTION
TL;DR: I repurposed this from the gPhoto2 snap, since darktable uses libgphoto2 to do tethering and camera/memory card import.  That seemed to be the easiest way to figure out how to support "what gPhoto2 does" as I mentioned in #27.

The layout is required due to the way ilibgphoto2 looks up camera drivers.  Without the layout, it can't find the libraries it expects to find in subdirectories of /usr/lib when unconfined, and then it can't find a connected camera.

One caveat: memory cards mounted as removable storage show up twice; once as /media/$USER/card and once as /var/lib/snapd/hostfs/media/$USER/card, and apparmor denies any access to the latter.
