### PR TITLE
Add libgphoto2 support and appropriate plugs.  Fixes #27 and #4 

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,14 @@ grade: stable
 confinement: strict
 base: core18
 
+layout:
+  /usr/lib/x86_64-linux-gnu/libgpm.so.2:
+    bind-file: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgpm.so
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgphoto2:
+    bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgphoto2
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgphoto2_port:
+    bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgphoto2_port
+
 apps:
   darktable:
     command: usr/bin/darktable --datadir $SNAP/usr/share/darktable --moduledir $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/darktable --configdir $SNAP_USER_DATA --localedir $SNAP/usr/share/locale
@@ -22,6 +30,10 @@ apps:
       - password-manager-service
       - network
       - network-bind
+      - raw-usb
+      - camera
+      - hardware-observe
+      - mount-observe
 
 parts:
   darktable:
@@ -74,7 +86,7 @@ parts:
       #
       # Camera detection/tethering/importing doesn't work, with no denials.
       # Need to investigate further before enabling this.
-      # - libgphoto2-dev
+      - libgphoto2-dev
       #
       # Need to test with cups-control interface
       # - libcups2-dev
@@ -98,3 +110,6 @@ parts:
       - libwebpmux3
       - libwmf0.2-7
       - libsecret-1-0
+      - libexif12
+      - libgphoto2-6
+      - libgphoto2-port12


### PR DESCRIPTION
TL;DR: re-request of #32, but without commingling a darktable version update.

This adds support for the gPhoto2 library and the interfaces it expects, since darktable uses gPhoto2 for both camera tethering and import from removable memory cards.  This should make the darktable snap usable for photographers who use the "import from camera" feature, which I suspect is a significant portion of the userbase.

The layout is required due to the way ilibgphoto2 looks up camera drivers. Without the layout, it can't find the libraries it expects to find in subdirectories of /usr/lib when unconfined, and then it can't find a connected camera.

One caveat: memory cards mounted as removable storage show up twice; once as /media/$USER/card and once as /var/lib/snapd/hostfs/media/$USER/card, and apparmor denies any access to the latter.

I have done some preliminary testing with this patch, and other than the caveat mentioned above, it seems to work well.